### PR TITLE
Use bbbike.org instead of mapzen.com

### DIFF
--- a/postgis/Dockerfile
+++ b/postgis/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/dooman87/openstreetmap-carto.git && \
-    wget https://s3.amazonaws.com/metro-extracts.mapzen.com/melbourne_australia.osm.pbf
+    wget https://download.bbbike.org/osm/bbbike/Melbourne/Melbourne.osm.pbf
 
 
 #Overriding init script to add hstore extension that osm2pgsql requires

--- a/postgis/initdb-postgis.sh
+++ b/postgis/initdb-postgis.sh
@@ -24,6 +24,6 @@ EOSQL
 done
 
 #import Melbourne city
-osm2pgsql --style /openstreetmap-carto/openstreetmap-carto.style -d gis -U postgres -k --slim /melbourne_australia.osm.pbf
+osm2pgsql --style /openstreetmap-carto/openstreetmap-carto.style -d gis -U postgres -k --slim /Melbourne.osm.pbf
 
 touch /var/lib/postgresql/data/DB_INITED


### PR DESCRIPTION
Mapzen ceased operations at the end of January 2018 - see https://mapzen.com/blog/shutdown/

Instead, use city extract from bbbike.org - see https://download.bbbike.org/osm/bbbike/Melbourne/